### PR TITLE
Redirect when remote root redirects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           command: |
             git clone https://github.com/coryb/osht ~/osht
-            cd t/environs && OSHT_LOCATION=~/osht/osht.sh ./01-smoke.sh && OSHT_LOCATION=~/osht/osht.sh ./02*.sh && OSHT_LOCATION=~/osht/osht.sh ./03*.sh && OSHT_LOCATION=~/osht/osht.sh ./04*.sh && OSHT_LOCATION=~/osht/osht.sh ./05*.sh
+            cd t/environs && OSHT_LOCATION=~/osht/osht.sh ./01-smoke.sh && OSHT_LOCATION=~/osht/osht.sh ./02*.sh && OSHT_LOCATION=~/osht/osht.sh ./03*.sh && OSHT_LOCATION=~/osht/osht.sh ./04-remote.sh && OSHT_LOCATION=~/osht/osht.sh ./04-remote-link.sh && OSHT_LOCATION=~/osht/osht.sh ./05*.sh
 
 workflows:
   version: 2.1

--- a/lib/DBIx/Class/Timestamps.pm
+++ b/lib/DBIx/Class/Timestamps.pm
@@ -29,7 +29,7 @@ sub add_timestamps {
 }
 
 sub now {
-    DateTime->now(time_zone => 'UTC');
+    DateTime->now(time_zone => 'local');
 }
 
 1;

--- a/lib/MirrorCache/Schema/ResultSet/Folder.pm
+++ b/lib/MirrorCache/Schema/ResultSet/Folder.pm
@@ -49,9 +49,9 @@ sub request_db_sync {
 
     my $sql = <<'END_SQL';
 insert into folder(path, db_sync_scheduled)
-values (?, now() at time zone 'UTC')
+values (?, now())
 on conflict(path) do update set
-db_sync_scheduled = case when folder.db_sync_scheduled > folder.db_sync_last then now() at time zone 'UTC' else folder.db_sync_scheduled end,
+db_sync_scheduled = CASE WHEN folder.db_sync_scheduled > folder.db_sync_last THEN folder.db_sync_scheduled ELSE now() end,
 db_sync_priority = ?
 END_SQL
     my $prep = $dbh->prepare($sql);

--- a/lib/MirrorCache/Task/FolderSyncScheduleFromMisses.pm
+++ b/lib/MirrorCache/Task/FolderSyncScheduleFromMisses.pm
@@ -61,6 +61,7 @@ sub _run {
         last unless $cnt;
         ($event_log_id, $paths) = $schema->resultset('AuditEvent')->path_misses($prev_event_log_id, $limit);
     }
+    $prev_event_log_id = 0 unless $prev_event_log_id;
     print(STDERR "$pref will retry with id: $prev_event_log_id\n");
     $job->note(event_log_id => $prev_event_log_id);
     return $job->retry({delay => 5});

--- a/lib/MirrorCache/WebAPI/Plugin/Dir.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Dir.pm
@@ -46,6 +46,7 @@ sub indx {
     my $path     = Mojo::Util::url_unescape(substr($c->req->url->path, $route_len));
     my $is_dir   = '/' eq substr($path, -1) ? 1 : 0;
     # trim trailing slash
+    $path = "/" unless $path;
     $path = substr($path,0,-1) if $is_dir && $path ne '/';
     if ($status) {
         return _render_stats_all($c, $path) if $status eq 'all';

--- a/lib/MirrorCache/WebAPI/Plugin/Dir.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Dir.pm
@@ -65,25 +65,25 @@ sub indx {
     # after this we are on remote root only
     # first try to render from DB, then check in $root
     my $rsFolder = $schema->resultset('Folder');
+    my $folder = $rsFolder->find({path => $path});
 
-    unless ($is_dir) {
+    if ($folder) {
+        return _render_dir($c, $path, $rsFolder, $folder) if ($folder->db_sync_last);
+    } else {
         my $f = Mojo::File->new($path);
-        my $folder = $rsFolder->find({path => $f->dirname});
+        $folder = $rsFolder->find({path => $f->dirname});
         unless ($folder) {
-            $c->emit_event('mc_path_miss', $f->dirname) unless $folder;
+            $c->emit_event('mc_path_miss', $f->dirname);
         } else {
             my $file = $schema->resultset('File')->find({ name => $f->basename, folder_id => $folder->id });
             if ($file) {
-                $c->mirrorcache->render_file($path);
+                return $c->mirrorcache->render_file($path);
             } else {
                 $c->emit_event('mc_path_miss', $f->dirname);
             }
         }
-    } else {
-        my $folder   = $rsFolder->find({path => $path});
-        return _render_dir($c, $path, $rsFolder, $folder) if $folder && ($folder->db_sync_last);
     }
-
+    # Now try to get content asynchronically
     my $tx = $c->render_later->tx;
     my $url = $c->app->mc->rootlocation;
     my $ua = Mojo::UserAgent->new;
@@ -92,10 +92,15 @@ sub indx {
         $c->emit_event('mc_debug', "head_p: $url, $path, $code, $is_dir");
         return $c->render(status => $code, text => "Error trying to check $url$path : $code") unless $code == 200 || $code == 301 || $code == 302;
         $c->emit_event('mc_debug', "head_p: $url, $path, $code, 2");
+
+        my $redir = $root->is_self_redirect($path);
+        return $c->redirect_to($route . $redir) if $redir;
+
         return render_dir_remote($c, $path, $rsFolder) if $is_dir;
 
         $ua->head_p($url . $path . '/')->then(sub {
-            return render_dir_remote($c, $path, $rsFolder) unless $code == 200 || $code == 301 || $code == 302;
+            $code = shift->res->code;
+            return render_dir_remote($c, $path, $rsFolder) if $code == 200 || $code == 301 || $code == 302;
             $c->mirrorcache->render_file($path);
         })->catch(sub {
             $c->mirrorcache->render_file($path);
@@ -104,13 +109,14 @@ sub indx {
         })->timeout(2)->wait;
     })->catch(sub {
         $c->render(status => 404, text => Dumper(\@_)); # TODO proper code?
-    })->timeout(2)->wait;
+    })->timeout(12)->wait;
 }
 
 sub render_dir_remote { 
     my $c      = shift;
     my $dir    = shift;
     my $rsFolder = shift;
+    my $tx = $c->render_later->tx;
 
     my $job_id = $c->backstage->enqueue_unless_scheduled_with_parameter_or_limit('folder_sync', $dir);
     unless ($job_id) {
@@ -121,6 +127,7 @@ sub render_dir_remote {
     $c->minion->result_p($job_id)->then(sub {
         $c->emit_event('mc_debug', "promiseok: $job_id");
         _render_dir($c, $dir, $rsFolder);
+        my $reftx = $tx;
     })->catch(sub {
         $c->emit_event('mc_debug', "promisefail: $job_id " . Dumper(\@_));
         
@@ -129,7 +136,8 @@ sub render_dir_remote {
             return _render_dir($c, $dir, $rsFolder);
         }
         $c->render(status => 500, text => Dumper($reason));
-    })->timeout(10)->wait;
+        my $reftx = $tx;
+    })->timeout(5)->wait;
 }
 
 sub _render_dir {

--- a/t/environs/04-remote-link.sh
+++ b/t/environs/04-remote-link.sh
@@ -1,0 +1,58 @@
+#!lib/test-in-container-environs.sh
+set -ex
+
+./environ.sh pg9-system2
+# git clone https://github.com/andrii-suse/MirrorCache || :
+./environ.sh ap9-system2
+./environ.sh ap8-system2
+./environ.sh ap7-system2
+
+./environ.sh mc9 $(pwd)/MirrorCache
+
+for x in ap7-system2 ap8-system2 ap9-system2; do
+    mkdir -p $x/dt/{folder1,folder2,folder3}
+    echo $x/dt/{folder1,folder2,folder3}/{file1,file2}.dat | xargs -n 1 touch
+done
+
+pg9*/status.sh 2 > /dev/null || {
+    pg9*/start.sh
+    pg9*/create.sh db mc_test
+    pg9*/sql.sh -f $(pwd)/MirrorCache/sql/schema.sql mc_test
+
+    ln -s $(pwd)/ap9-system2/dt/folder1 $(pwd)/ap9-system2/dt/link
+echo '    RewriteEngine On
+    RewriteBase "/"
+    RewriteRule ^link(/.*)?$ folder1$1 [R]
+' > ap9-system2/directory-rewrite.conf
+
+echo 'LoadModule rewrite_module    /usr/lib64/apache2-prefork/mod_rewrite.so' > ap9-system2/extra-rewrite.conf
+}
+
+mc9*/configure_db.sh pg9
+export MIRRORCACHE_ROOT=http://$(ap9*/print_address.sh)
+
+for x in ap7-system2 ap8-system2 ap9-system2; do
+    $x/start.sh
+done
+
+# make sure rewrite works properly in apache
+curl -I $(ap9*/print_address.sh)/link | grep -A3 302 | grep folder1
+
+pg9*/sql.sh -c "insert into folder(path, db_sync_last) select '/', now()" mc_test 
+
+mc9*/start.sh
+mc9*/status.sh
+
+pg9*/sql.sh -c "insert into server(hostname,urldir,enabled,country,region) select '127.0.0.1:1304','/','t','us',''" mc_test 
+pg9*/sql.sh -c "insert into server(hostname,urldir,enabled,country,region) select '127.0.0.1:1314','/','t','us',''" mc_test
+
+mc9*/backstage/job.sh folder_sync_schedule_from_misses
+mc9*/backstage/job.sh folder_sync_schedule
+mc9*/backstage/start.sh
+
+################################################
+# Test symlinks
+
+curl -Is http://127.0.0.1:3190/download/link
+curl -Is http://127.0.0.1:3190/download/link | grep -A4 -E '301|302' | grep ': /download/folder1'
+################################################


### PR DESCRIPTION
Let MirrorCache redirect directory listing to another directory when remote root does the same.
Use localtime everywhere instead of UTC.