### PR TITLE
Add Users page for user management

### DIFF
--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -107,6 +107,7 @@
 < http://timeago.yarp.com/jquery.timeago.js
 < javascripts/mirrorcache.js
 < javascripts/admintable.js
+< javascripts/admin_user.js
 < https://raw.githubusercontent.com/bootstrapthemesco/bootstrap-4-multi-dropdown-navbar/beta2.0/js/bootstrap-4-navbar.js
 < https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.js
 < https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.js

--- a/assets/javascripts/admin_user.js
+++ b/assets/javascripts/admin_user.js
@@ -1,0 +1,65 @@
+function setup_admin_user() {
+    window.admin_user_table = $('#users').DataTable({
+        order: [
+            [0, 'asc']
+        ]
+    });
+
+    $('#users').on('change', 'input[name="role"]:radio', function() {
+        var username = $(this).parents('tr').find('.name').text();
+        var role = $(this).attr('id');
+        role = $('label[for="' + role + '"]').text();
+
+        function findDefault(form) {
+            return form.find('input[class="default"]').first();
+        }
+
+        function rollback(form) {
+            findDefault(form).prop('checked', 'checked');
+        }
+
+        var form = $(this).parent('form');
+        if (!confirm("Are you sure to put " + username + " into role: " + $.trim(role) + "?")) {
+            rollback(form);
+            return;
+        }
+
+        var data = form.serializeArray();
+        var newRole = data[0].value;
+
+        $.ajax({
+            type: 'POST',
+            url: form.attr('action'),
+            data: jQuery.param(data),
+            success: function(data) {
+                findDefault(form).removeClass('default');
+                form.find('input[value="' + newRole + '"]').addClass('default');
+            },
+            error: function(err) {
+                rollback(form);
+                addFlash('danger', 'An error occurred when changing the user role');
+            }
+        });
+    });
+
+    window.deleteUser = function(id) {
+        if (!confirm("Are you sure you want to delete this user?"))
+            return;
+
+        $.ajax({
+            url: '/admin/user/' + id,
+            method: 'DELETE',
+            dataType: 'json',
+            success: function() {
+                addFlash('info', 'The user was deleted successfully.');
+                window.admin_user_table.row($("#user_" + id)).remove().draw();
+            },
+            error: function(xhr, ajaxOptions, thrownError) {
+                if (xhr.responseJSON && xhr.responseJSON.error)
+                    addFlash('danger', xhr.responseJSON.error);
+                else
+                    addFlash('danger', 'An error has ocurred. Maybe there are unsatisfied foreign key restrictions in the DB for this user.');
+            }
+        });
+    };
+}

--- a/lib/MirrorCache/WebAPI.pm
+++ b/lib/MirrorCache/WebAPI.pm
@@ -99,6 +99,12 @@ sub startup {
 
         $admin_r->delete('/folder/<id:num>')->to('folder#delete_cascade');
         $admin_r->delete('/folder_diff/<id:num>')->to('folder#delete_diff');
+        
+        $admin_r->get('/users')->name('get_users')->to('user#index');
+        $admin_r->post('/user/:userid')->name('post_user')->to('user#update');
+
+        my $rest_user_r = $admin_auth->any('/')->to(namespace => 'MirrorCache::WebAPI::Controller::Rest');
+        $rest_user_r->delete('/user/<id:num>')->name('delete_user')->to('user#delete');
 
         $r->get('/index' => sub { shift->render('main/index') });
         $r->get('/' => sub { shift->render('main/index') })->name('index');

--- a/lib/MirrorCache/WebAPI/Controller/Admin/User.pm
+++ b/lib/MirrorCache/WebAPI/Controller/Admin/User.pm
@@ -1,0 +1,55 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package MirrorCache::WebAPI::Controller::Admin::User;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub index {
+    my ($self) = @_;
+    my @users = $self->schema->resultset("Acc")->search(undef)->all;
+
+    $self->stash('users', \@users);
+    $self->render('app/user/index');
+}
+
+sub update {
+    my ($self)      = @_;
+    my $set         = $self->schema->resultset('Acc');
+    my $is_admin    = 0;
+    my $is_operator = 0;
+    my $role        = $self->param('role') // 'user';
+
+    if ($role eq 'admin') {
+        $is_admin    = 1;
+        $is_operator = 1;
+    }
+    elsif ($role eq 'operator') {
+        $is_operator = 1;
+    }
+
+    my $user = $set->find($self->param('userid'));
+    if (!$user) {
+        $self->flash('error', "Can't find that user");
+    }
+    else {
+        $user->update({is_admin => $is_admin, is_operator => $is_operator});
+        $self->flash('info', 'User ' . $user->nickname . ' updated');
+        $self->emit_event('user_update_res', {nickname => $user->nickname, role => $role});
+    }
+
+    $self->redirect_to($self->url_for('get_users'));
+}
+
+1;

--- a/lib/MirrorCache/WebAPI/Controller/Rest/User.pm
+++ b/lib/MirrorCache/WebAPI/Controller/Rest/User.pm
@@ -1,0 +1,28 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package MirrorCache::WebAPI::Controller::Rest::User;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub delete {
+    my ($self) = @_;
+    my $user = $self->schema->resultset('Acc')->find($self->param('id'));
+    return $self->render(json => {error => 'Not found'}, status => 404) unless $user;
+    my $result = $user->delete();
+    $self->emit_event('mirrorcache_user_deleted', {username => $user->username});
+    $self->render(json => {result => $result});
+}
+
+1;

--- a/t/environs/11-user-form.sh
+++ b/t/environs/11-user-form.sh
@@ -1,0 +1,28 @@
+#!lib/test-in-container-environs.sh
+set -ex
+
+# Ensure that route for user management page requests authentication
+# Ensure that routes for user management are protected
+
+./environ.sh pg9-system2
+
+./environ.sh mc9 $(pwd)/MirrorCache
+pg9*/status.sh 2 > /dev/null || pg9*/start.sh
+
+pg9*/create.sh db mc_test
+pg9*/sql.sh -f $(pwd)/MirrorCache/sql/schema.sql mc_test
+
+mc9*/configure_db.sh pg9
+mc9*/start.sh
+
+pg9*/sql.sh -c "insert into acc(username,email,fullname,nickname,is_operator,is_admin,t_created,t_updated) select 'eli','eli@test','Eli Test','eli',0,0,'2021-01-14 11:19:25','2021-01-14 11:19:25'" mc_test
+
+mc9*/curl.sh admin/users -I | grep -E '302|/login'
+
+mc9*/curl.sh admin/user/1 -I | grep -E '404|Not Found'
+
+mc9*/curl.sh admin/user/1 -X POST -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data-raw 'role=admin'
+test 0 == $(pg9*/sql.sh -t -c "select count(*) from acc where is_admin=1 and is_operator=1" mc_test)
+
+mc9*/curl.sh admin/user/1 -X POST -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data-raw 'role=operator'
+test 0 == $(pg9*/sql.sh -t -c "select count(*) from acc where is_admin=0 and is_operator=1" mc_test)

--- a/t/environs/11-user-management.sh
+++ b/t/environs/11-user-management.sh
@@ -1,0 +1,35 @@
+#!lib/test-in-container-environs.sh
+set -ex
+
+# Ensure that routes for user management work
+
+./environ.sh pg9-system2
+
+./environ.sh mc9 $(pwd)/MirrorCache
+pg9*/status.sh 2 > /dev/null || pg9*/start.sh
+
+pg9*/create.sh db mc_test
+pg9*/sql.sh -f $(pwd)/MirrorCache/sql/schema.sql mc_test
+
+mc9*/configure_db.sh pg9
+
+# start MirrorCache with no authentication for all routes under /admin 
+MIRRORCACHE_TEST_TRUST_AUTH=1 mc9*/start.sh
+
+pg9*/sql.sh -c "insert into acc(username,email,fullname,nickname,is_operator,is_admin,t_created,t_updated) select 'eli','eli@test','Eli Test','eli',0,0,'2021-01-14 11:19:25','2021-01-14 11:19:25'" mc_test
+pg9*/sql.sh -t -c "select * from acc" mc_test
+
+mc9*/curl.sh admin/users -I | grep '200'
+
+mc9*/curl.sh admin/user/1 -X POST -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data-raw 'role=admin'
+test 1 == $(pg9*/sql.sh -t -c "select count(*) from acc where is_admin=1 and is_operator=1" mc_test)
+
+mc9*/curl.sh admin/user/1 -X POST -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data-raw 'role=operator'
+test 1 == $(pg9*/sql.sh -t -c "select count(*) from acc where is_admin=0 and is_operator=1" mc_test)
+
+mc9*/curl.sh admin/user/1 -X POST -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data-raw 'role=user'
+test 1 == $(pg9*/sql.sh -t -c "select count(*) from acc where is_admin=0 and is_operator=0" mc_test)
+
+mc9*/curl.sh admin/user/1 -X DELETE >/dev/null
+mc9*/curl.sh admin/user/1 -X DELETE | grep -E 'error|Not found'
+test 0 == $(pg9*/sql.sh -t -c "select count(*) from acc" mc_test)

--- a/templates/app/user/index.html.ep
+++ b/templates/app/user/index.html.ep
@@ -1,0 +1,73 @@
+% layout 'bootstrap';
+% title 'Users';
+
+% content_for 'ready_function' => begin
+    setup_admin_user();
+% end
+
+% my $show_user_actions = is_admin;
+
+<div class="row">
+    <div class="col-sm-12">
+        <h2><%= title %></h2>
+
+        %= include 'layouts/info'
+
+        <table id="users" class="display table table-striped">
+            <thead>
+                <tr>
+                    <th>Username</th>
+                    <th>Email</th>
+                    <th>Name</th>
+                    <th>Nick</th>
+                    <th>Role</th>
+                    % if ($show_user_actions) {
+                    <th></th>
+                    % }
+                </tr>
+            </thead>
+            <tbody>
+                % for my $user (@$users) {
+                    <tr id="user_<%= $user->id %>">
+                        <td class="username"><%= $user->username %></td>
+                        <td class="email"><%= $user->email %></td>
+                        <td class="name"><%= $user->fullname %></td>
+                        <td class="nick"><%= $user->nickname %></td>
+                        <td class="role" data-order="<%= $user->is_admin %><%= $user->is_operator %>">
+                            %= form_for url_for('post_user', userid => $user->id) => (method => 'POST') => begin
+                                % my @selects = ['', '', ''];
+                                % my $select = 0;
+                                % if ($user->is_admin) {
+                                    %   $select = 2;
+                                % } elsif ($user->is_operator) {
+                                %   $select = 1;
+                % }
+                % $selects[$select] = Mojo::ByteStream->new("checked='checked' class='default'");
+                <input type="radio" name="role" value="user" id="<%= $user->id %>_user" <%= $selects[0] %>/>
+                <label for="<%= $user->id %>_user">
+                    User
+                </label>
+                <input type="radio" name="role" value="operator" id="<%= $user->id %>_operator" <%= $selects[1] %>/>
+                <label for="<%= $user->id %>_operator">
+                    Operator
+                </label>
+                <input type="radio" name="role" value="admin" id="<%= $user->id %>_admin" <%= $selects[2] %>/>
+                <label for="<%= $user->id %>_admin">
+                    Administrator
+                </label>
+                            % end
+                        </td>
+                        % if ($show_user_actions) {
+                        <td class="text-nowrap">
+                            <a class="btn p-0">
+                                <i class="fa fa-trash" aria-hidden="true" onclick="deleteUser(<%= $user->id %>)"></i>
+                            </a>
+                        </td>
+                        % }
+                    </tr>
+            % }
+            </tbody>
+        </table>
+    </div>
+
+</div>

--- a/templates/layouts/navbar.html.ep
+++ b/templates/layouts/navbar.html.ep
@@ -25,6 +25,9 @@
                   %= link_to 'Servers' => url_for('server') => class => 'dropdown-item'
                   % if (is_operator) {
                   %= link_to 'Background jobs' => url_for('minion') => class => 'dropdown-item'
+                  % }
+                  % if (is_admin) {
+                  %= link_to 'Users' => url_for('get_users') => class => 'dropdown-item'
                   % } 
                   %= link_to 'My IP' => url_for('/rest/myip') => class => 'dropdown-item'
                   %= link_to 'Logout' => url_for('logout') => class => 'dropdown-item'


### PR DESCRIPTION
Roadmap on `Users` page:

- [x] Write tests
- [x] Add page and link to it from the main page
- [x] Make page available and editable only to and by admins, by requesting authentication for routes defined by this page
- [x] Only `is_admin` and `is_operator` fields should be editable