### PR TITLE
Add a way to keep MirrorCache container running

### DIFF
--- a/t/lib/test-in-container-environs.sh
+++ b/t/lib/test-in-container-environs.sh
@@ -51,7 +51,12 @@ docker rm -f "$containername" >&/dev/null || :
 
 map_port=""
 [ -z "$EXPOSE_PORT" ] || map_port="-p 80:$EXPOSE_PORT"
-docker run $map_port --rm --name "$containername" --env REBUILD=1 -d -v"$thisdir/../../..":/opt/environs/MirrorCache -- $ident.image
+mc_database=""
+if [[ -n "$MIRRORCACHE_CITY_MMDB" ]]; then
+    mc_database="--env MIRRORCACHE_CITY_MMDB=$MIRRORCACHE_CITY_MMDB"
+    [[ -f "$MIRRORCACHE_CITY_MMDB" ]] && mc_database+=" -v $MIRRORCACHE_CITY_MMDB:$MIRRORCACHE_CITY_MMDB"
+fi
+docker run $map_port $mc_database --rm --name "$containername" --env REBUILD=1 -d -v"$thisdir/../../..":/opt/environs/MirrorCache -- $ident.image
 
 in_cleanup=0
 


### PR DESCRIPTION
- Introduces possibility to keep a test container runing, if `EXPOSE_PORT` is set to the port inside of container you want to map to port 80 on the host: `EXPOSE_PORT=3190` for a `mc9` mirrorcache instance will make MirrorCache available at localhost:80
- Also, if `MIRRORCACHE_CITY_MMDB` is set, it will start the container with that, for example: `MIRRORCACHE_CITY_MMDB=/path/to/file` results in:
 `docker run --env MIRRORCACHE_CITY_MMDB=/path/to/file -v /path/to/file:/path/to/file`