### PR TITLE
Optimize mirrors sql

### DIFF
--- a/lib/MirrorCache/Schema/ResultSet/Server.pm
+++ b/lib/MirrorCache/Schema/ResultSet/Server.pm
@@ -59,6 +59,10 @@ join (select ?::server_capability_t as cap) http on 1 = 1
 join (select 'ipv4'::server_capability_t as capability union select 'ipv6'::server_capability_t) ipvall on 1 = 1
 join (select 'http'::server_capability_t as capability union select 'https'::server_capability_t) httpall on 1 = 1
 join server s on s.enabled
+join folder_diff_server fds on fds.server_id = s.id
+join folder_diff fd on fd.id = fds.folder_diff_id
+join file fl on fl.folder_id = ? and fl.name = ? and fl.folder_id = fd.folder_id and fl.dt <= fd.dt
+left join folder_diff_file fdf on fdf.file_id = fl.id and fdf.folder_diff_id = fd.id
 left join server_capability_check chk on chk.server_id = s.id and chk.capability = httpall.capability
 left join server_capability_check chk_old on chk_old.server_id = s.id and chk_old.capability = httpall.capability and chk_old.dt > chk.dt
 left join server_capability_check chk6 on chk6.server_id = s.id and chk6.capability = ipvall.capability
@@ -68,10 +72,6 @@ left join server_capability_declaration cap6 on cap6.server_id  = s.id and cap6.
 left join server_capability_force      fcap  on fcap.server_id  = s.id and fcap.capability  = httpall.capability
 left join server_capability_force      fcap6 on fcap6.server_id = s.id and fcap6.capability = ipvall.capability
 left join server_capability_declaration cap_asn_only on s.id = cap_asn_only.server_id and cap_asn_only.capability = 'as_only'
-join folder_diff_server fds on fds.server_id = s.id
-join folder_diff fd on fd.id = fds.folder_diff_id
-join file fl on fl.folder_id = ? and fl.name = ? and fl.folder_id = fd.folder_id and fl.dt <= fd.dt
-left join folder_diff_file fdf on fdf.file_id = fl.id and fdf.folder_diff_id = fd.id
 where fdf.file_id is NULL
 and fcap.server_id is NULL
 and fcap6.server_id is NULL


### PR DESCRIPTION
It looks postgres applies folder/files filter too late.
The change decreases query execution on 600 folders and ~200K files from 4s down to ~0.5s