### PR TITLE
Dont log miss event for folder request

### DIFF
--- a/lib/MirrorCache/Task/FolderSyncScheduleFromMisses.pm
+++ b/lib/MirrorCache/Task/FolderSyncScheduleFromMisses.pm
@@ -47,6 +47,7 @@ sub _run {
         $prev_event_log_id = $event_log_id;
         print(STDERR "$pref read id from event log up to: $event_log_id\n");
         for my $path (sort keys %$path_country_map) {
+            my $country = $path_country_map->{$path}; 
             my $folder = $rs->find({ path => $path });
             if (!$folder) {
                 if (!$app->mc->root->is_dir($path)) {
@@ -54,7 +55,7 @@ sub _run {
                     next unless $app->mc->root->is_dir($path);
                 }
             }
-            $rs->request_db_sync( $path, $path_country_map->{$path} );
+            $rs->request_db_sync( $path, $country );
             $cnt = $cnt + 1;
         }
         for my $country (@$country_list) {

--- a/t/environs/04-remote-link.sh
+++ b/t/environs/04-remote-link.sh
@@ -56,3 +56,11 @@ mc9*/backstage/start.sh
 curl -Is http://127.0.0.1:3190/download/link
 curl -Is http://127.0.0.1:3190/download/link | grep -A4 -E '301|302' | grep ': /download/folder1'
 ################################################
+
+# make sure symlinks still work after further folder_sync_schedule_from_misses
+sleep 10
+curl -Is http://127.0.0.1:3190/download/link
+curl -Is http://127.0.0.1:3190/download/link | grep -A4 -E '301|302' | grep ': /download/folder1'
+sleep 10
+curl -Is http://127.0.0.1:3190/download/link
+curl -Is http://127.0.0.1:3190/download/link | grep -A4 -E '301|302' | grep ': /download/folder1'


### PR DESCRIPTION
This is not needed because we schedule FolderSync anyway to render it.
Plus it solves problem when rows in folder table are created for symlinks by ScheduleFromMisses job.