### PR TITLE
Enforce strict scheme handling

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -9,6 +9,7 @@ MirrorCache can be configured with following environment variables:
   * MIRRORCACHE_TOP_FOLDERS (space separated values) may be set to automatically redirect /folder to /download/folder.
   * For reference of using MOJO_LISTEN variable refer Mojolicious documentation, e.g. `MOJO_LISTEN=http://*:8000`
   * It is recommended to run MirrorCache daemon behind another streamline WebService, e.g. Apache or haproxy. Thus `MOJO_REVERSE_PROXY=1` will be needed.
+  * MIRRORCACHE_FALLBACK_HTTPS_REDIRECT if specified, it will be used for redirect when no mirror is found for https request, e.g. MIRRORCACHE_FALLBACK_HTTPS_REDIRECT=https://downloadcontent.opensuse.org .
   * MIRRORCACHE_METALINK_PUBLISHER may be set to customize publisher in metalink generation.
   * MIRRORCACHE_METALINK_PUBLISHER_URL may be set to customize url of publisher in metalink generation.
 

--- a/lib/MirrorCache/WebAPI/Plugin/RootRemote.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RootRemote.pm
@@ -38,7 +38,11 @@ sub register {
     (my $self, $app) = @_;
     $rooturl = $app->mc->rootlocation;
     $rooturllen = length $rooturl;
-    $rooturls = $rooturl =~ s/http:/https:/r;
+    if (my $fallback = $ENV{MIRRORCACHE_FALLBACK_HTTPS_REDIRECT}) {
+        $rooturls = $fallback;
+    } else {
+        $rooturls = $rooturl =~ s/http:/https:/r;
+    }
     $rooturlslen = length $rooturls;
     $app->helper( 'mc.root' => sub { $self->singleton; });
 }

--- a/t/environs/09-stability-force.sh
+++ b/t/environs/09-stability-force.sh
@@ -77,8 +77,9 @@ mc9*/backstage/shoot.sh
 
 curl -Is http://127.0.0.1:3190/download/folder1/file1.dat | grep -v $(ap7*/print_address.sh)
 
-# now scan those mirrors which were force dicabled
+# now scan those mirrors which were force disabled
 mc9*/backstage/job.sh -e mirror_force_ups
+mc9*/backstage/job.sh -e mirror_probe -a '["us"]'
 mc9*/backstage/shoot.sh
 
 # ap7 now should serve the request


### PR DESCRIPTION
1. Do not suggest http mirrors for https requests and vice versa. (Before different schema had just lower priority).
2. Require presence of a row in server_capability_check for a redirect candidate. (Unless no checks are present at all for the country). 
3. Introduce MIRRORCACHE_FALLBACK_HTTPS_REDIRECT variable.