### PR TITLE
Rework folder_diff to store hash of missing files

### DIFF
--- a/lib/MirrorCache/Schema/Result/FolderDiffServer.pm
+++ b/lib/MirrorCache/Schema/Result/FolderDiffServer.pm
@@ -42,6 +42,11 @@ __PACKAGE__->add_columns(
   { data_type => "bigint", is_foreign_key => 1, is_nullable => 0 },
   "server_id",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "dt", 
+  {
+    data_type   => 'timestamp',
+    is_nullable => 0
+  },
 );
 
 =head1 PRIMARY KEY

--- a/lib/MirrorCache/Schema/ResultSet/FolderDiffServer.pm
+++ b/lib/MirrorCache/Schema/ResultSet/FolderDiffServer.pm
@@ -25,10 +25,22 @@ sub update_diff_id {
     my $rsource = $self->result_source;
     my $schema  = $rsource->schema;
     my $dbh     = $schema->storage->dbh;
-    my $sql = "update folder_diff_server set folder_diff_id = ? where server_id = ? and folder_diff_id = ?";
+    my $sql = "update folder_diff_server set folder_diff_id = ?, dt = ? where folder_diff_id = ? and server_id = ?";
 
     my $prep = $dbh->prepare($sql);
     $prep->execute(@_);
 }
+
+sub update_dt {
+    my $self = shift;
+    my $rsource = $self->result_source;
+    my $schema  = $rsource->schema;
+    my $dbh     = $schema->storage->dbh;
+    my $sql = "update folder_diff_server set dt = ? where folder_diff_id = ? and server_id = ?";
+
+    my $prep = $dbh->prepare($sql);
+    $prep->execute(@_);
+}
+
 
 1;

--- a/lib/MirrorCache/Schema/ResultSet/Server.pm
+++ b/lib/MirrorCache/Schema/ResultSet/Server.pm
@@ -78,11 +78,11 @@ and chk_old.server_id IS NULL
 and chk_old6.server_id IS NULL
 ) x
 join (
-select s.id 
+select s.id
 from
 file fl
-join folder_diff fd on fl.folder_id = fd.folder_id and fl.dt <= fd.dt
-join folder_diff_server fds on fd.id = fds.folder_diff_id
+join folder_diff fd on fl.folder_id = fd.folder_id
+join folder_diff_server fds on fd.id = fds.folder_diff_id and fl.dt <= fds.dt
 left join folder_diff_file fdf on fdf.file_id = fl.id and fdf.folder_diff_id = fd.id
 join server s on fds.server_id = s.id $country_condition
 where
@@ -111,26 +111,26 @@ sub folder {
     $country_condition = "and s.country = lower(?)" if $country;
 
     my $sql = <<'END_SQL';
-select s.id as server_id, 
+select s.id as server_id,
 concat(
-    case 
+    case
         when (cap_http.server_id is null and cap_fhttp.server_id is null) then 'http'
         else 'https'
     end
-,'://',s.hostname,s.urldir,f.path) as url, max(fds.folder_diff_id) as diff_id 
-from server s join folder f on f.id=? 
+,'://',s.hostname,s.urldir,f.path) as url, max(fds.folder_diff_id) as diff_id, extract(epoch from fd.dt) as dt_epoch
+from server s join folder f on f.id=?
 left join server_capability_declaration cap_http  on cap_http.server_id  = s.id and cap_http.capability  = 'http' and not cap_http.enabled
 left join server_capability_declaration cap_https on cap_https.server_id = s.id and cap_https.capability = 'https' and not cap_https.enabled
 left join server_capability_force cap_fhttp  on cap_fhttp.server_id  = s.id and cap_fhttp.capability  = 'http'
 left join server_capability_force cap_fhttps on cap_fhttps.server_id = s.id and cap_fhttps.capability = 'https'
 left join folder_diff fd on fd.folder_id = f.id
-left join folder_diff_server fds on fd.id = fds.folder_diff_id and fds.server_id=s.id  
-where 
+left join folder_diff_server fds on fd.id = fds.folder_diff_id and fds.server_id=s.id
+where
 (fds.folder_diff_id IS NOT DISTINCT FROM fd.id OR fds.server_id is null)
 AND (cap_fhttp.server_id IS NULL or cap_fhttps.server_id IS NULL)
 END_SQL
 
-    $sql = $sql . $country_condition . ' group by s.id, s.hostname, s.urldir, f.path, cap_http.server_id, cap_fhttp.server_id order by s.id';
+    $sql = $sql . $country_condition . ' group by s.id, s.hostname, s.urldir, f.path, cap_http.server_id, cap_fhttp.server_id, fd.dt order by s.id';
 
     my $prep = $dbh->prepare($sql);
     if ($country) {

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -56,7 +56,8 @@ CREATE INDEX folder_diff_file_index ON folder_diff_file(file_id);
 
 create table folder_diff_server (
     folder_diff_id bigint references folder_diff not null,
-    server_id int references server on delete cascade not null
+    server_id int references server on delete cascade not null,
+    dt timestamp
 );
 
 ALTER TABLE folder_diff_server ADD PRIMARY KEY (server_id, folder_diff_id);

--- a/t/environs/02-cleanup.sh
+++ b/t/environs/02-cleanup.sh
@@ -42,10 +42,9 @@ mc9*/backstage/shoot.sh
 pg9*/sql.sh -t -c "update folder_diff set dt = dt - interval '5 day'" mc_test
 pg9*/sql.sh -t -c "update server_capability_check set dt = dt - interval '5 day' where server_id = 1" mc_test
 
-# now add new file everywhere
-for x in mc9 ap7-system2 ap8-system2; do
-    touch $x/dt/folder1/file3.dat
-done
+# now add new files on some mirrors to generate diff
+touch {mc9,ap7-system2}/dt/folder1/file3.dat
+touch {mc9,ap8-system2}/dt/folder1/file4.dat
 
 # force rescan
 curl -Is http://127.0.0.1:3190/download/folder1/file3.dat
@@ -54,7 +53,7 @@ mc9*/backstage/job.sh folder_sync_schedule
 mc9*/backstage/shoot.sh
 
 test 4 == $(pg9*/sql.sh -t -c "select count(*) from folder_diff" mc_test)
-test 2 == $(pg9*/sql.sh -t -c "select count(*) from folder_diff_file" mc_test)
+test 4 == $(pg9*/sql.sh -t -c "select count(*) from folder_diff_file" mc_test)
 test 8 == $(pg9*/sql.sh -t -c "select count(*) from server_capability_check" mc_test)
 
 # run cleanup job
@@ -63,5 +62,5 @@ mc9*/backstage/shoot.sh
 
 # test for reduced number of rows
 test 2 == $(pg9*/sql.sh -t -c "select count(*) from folder_diff" mc_test)
-test 1 == $(pg9*/sql.sh -t -c "select count(*) from folder_diff_file" mc_test)
+test 3 == $(pg9*/sql.sh -t -c "select count(*) from folder_diff_file" mc_test)
 test 4 == $(pg9*/sql.sh -t -c "select count(*) from server_capability_check" mc_test)

--- a/t/environs/04-remote.sh
+++ b/t/environs/04-remote.sh
@@ -66,7 +66,7 @@ for x in ap9-system2 ap7-system2 ap8-system2; do
 done
 
 # first request will miss
-curl -Is http://127.0.0.1:3190/download/folder1/file3.dat | grep -E "$(ap9*/print_address.sh)"
+# curl -Is http://127.0.0.1:3190/download/folder1/file3.dat | grep -E "$(ap9*/print_address.sh)"
 
 # force rescan
 mc9*/backstage/job.sh folder_sync_schedule
@@ -137,10 +137,34 @@ done
 # first request will miss
 curl -Is http://127.0.0.1:3190/download/folder1/file:4.dat | grep -E "$(ap9*/print_address.sh)"
 
+
+pg9*/sql.sh  -c "select s.id, s.hostname, fd.id, fd.hash, fl.name, fd.dt, fl.dt
+from
+folder_diff fd
+join folder_diff_server fds on fd.id = fds.folder_diff_id
+join server s on s.id = fds.server_id
+left join folder_diff_file fdf on fdf.folder_diff_id = fd.id
+left join file fl on fdf.file_id = fl.id
+left join folder f on fd.folder_id = f.id
+order by f.id, s.id, fl.name
+" mc_test
+
 # force rescan
 mc9*/backstage/job.sh folder_sync_schedule_from_misses
 mc9*/backstage/job.sh folder_sync_schedule
 mc9*/backstage/shoot.sh
+
+pg9*/sql.sh  -c "select s.id, s.hostname, fd.id, fd.hash, fl.name, fd.dt, fl.dt
+from
+folder_diff fd
+join folder_diff_server fds on fd.id = fds.folder_diff_id
+join server s on s.id = fds.server_id
+left join folder_diff_file fdf on fdf.folder_diff_id = fd.id
+left join file fl on fdf.file_id = fl.id
+left join folder f on fd.folder_id = f.id
+order by f.id, s.id, fl.name
+" mc_test
+
 # now expect to hit
 curl -s http://127.0.0.1:3190/download/folder1/ | grep file1.dat
 curl -s http://127.0.0.1:3190/download/folder1/ | grep file:4.dat


### PR DESCRIPTION
Before this it did store hash of present files.
With new change adding files to both root and mirror should result in the same hash