### PR TITLE
Fix bug populating rows in folder_diff_server

### DIFF
--- a/lib/MirrorCache/Schema/ResultSet/Server.pm
+++ b/lib/MirrorCache/Schema/ResultSet/Server.pm
@@ -117,7 +117,7 @@ concat(
         when (cap_http.server_id is null and cap_fhttp.server_id is null) then 'http'
         else 'https'
     end
-,'://',s.hostname,s.urldir,f.path) as url, max(fds.folder_diff_id) as diff_id, extract(epoch from fd.dt) as dt_epoch
+,'://',s.hostname,s.urldir,f.path) as url, max(fds.folder_diff_id) as diff_id, extract(epoch from max(fd.dt)) as dt_epoch
 from server s join folder f on f.id=?
 left join server_capability_declaration cap_http  on cap_http.server_id  = s.id and cap_http.capability  = 'http' and not cap_http.enabled
 left join server_capability_declaration cap_https on cap_https.server_id = s.id and cap_https.capability = 'https' and not cap_https.enabled
@@ -130,7 +130,7 @@ where
 AND (cap_fhttp.server_id IS NULL or cap_fhttps.server_id IS NULL)
 END_SQL
 
-    $sql = $sql . $country_condition . ' group by s.id, s.hostname, s.urldir, f.path, cap_http.server_id, cap_fhttp.server_id, fd.dt order by s.id';
+    $sql = $sql . $country_condition . ' group by s.id, s.hostname, s.urldir, f.path, cap_http.server_id, cap_fhttp.server_id order by s.id';
 
     my $prep = $dbh->prepare($sql);
     if ($country) {


### PR DESCRIPTION
After deployment problem rows must be cleaned with sql command:

```
delete from folder_diff_server where (folder_diff_id, server_id) in (select fds1.folder_diff_id, fds1.server_id from 
folder_diff_server fds1 
join folder_diff fd1 on fd1.id = fds1.folder_diff_id
join folder_diff_server fds2 on fds1.server_id = fds2.server_id and fds1.dt < fds2.dt
join folder_diff fd2 on fd2.id = fds2.folder_diff_id and fd1.folder_id = fd2.folder_id);
```
