### PR TITLE
Add unique index on hostnames

### DIFF
--- a/dist/salt/profile/mirrorcache/files/usr/share/mirrorcache/sql/mirrors-eu.sql
+++ b/dist/salt/profile/mirrorcache/files/usr/share/mirrorcache/sql/mirrors-eu.sql
@@ -72,7 +72,6 @@ insert into server(hostname,urldir,enabled,country,region) select 'mirror.linux-
 insert into server(hostname,urldir,enabled,country,region) select 'mirror.tspu.ru','/opensuse','t','ru','';
 insert into server(hostname,urldir,enabled,country,region) select 'mirror.yandex.ru','/opensuse','t','ru','';
 insert into server(hostname,urldir,enabled,country,region) select 'ftp.acc.umu.se','/mirror/opensuse.org','t','se','';
-insert into server(hostname,urldir,enabled,country,region) select 'ftp.acc.umu.se','/mirror/opensuse.org','t','se','';
 insert into server(hostname,urldir,enabled,country,region) select 'ftp.lysator.liu.se','/pub/opensuse','t','se','';
 insert into server(hostname,urldir,enabled,country,region) select 'mirrors.xgroup.si','/opensuse','t','si','';
 insert into server(hostname,urldir,enabled,country,region) select 'tux.rainside.sk','/opensuse','t','sk','';

--- a/dist/salt/profile/mirrorcache/files/usr/share/mirrorcache/sql/mirrors-na.sql
+++ b/dist/salt/profile/mirrorcache/files/usr/share/mirrorcache/sql/mirrors-na.sql
@@ -16,7 +16,6 @@ insert into server(hostname,urldir,enabled,country,region) select 'suse.mobile-c
 insert into server(hostname,urldir,enabled,country,region) select 'ewr.edge.kernel.org','/opensuse','t','us','';
 insert into server(hostname,urldir,enabled,country,region) select 'sjc.edge.kernel.org','/opensuse','t','us','';
 insert into server(hostname,urldir,enabled,country,region) select 'provo-mirror.opensuse.org','/','t','us','';
-insert into server(hostname,urldir,enabled,country,region) select 'provo-mirror.opensuse.org','/','t','us','';
 insert into server(hostname,urldir,enabled,country,region) select 'mirror.math.princeton.edu','/pub/opensuse-full/opensuse','t','us','';
 insert into server(hostname,urldir,enabled,country,region) select 'plug-mirror.rcac.purdue.edu','/opensuse','t','us','';
 insert into server(hostname,urldir,enabled,country,region) select 'mirror.rackspace.com','/openSUSE','t','us','';

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -28,7 +28,7 @@ create table redirect (
 
 create table server (
     id serial NOT NULL PRIMARY KEY,
-    hostname  varchar(128) NOT NULL,
+    hostname  varchar(128) NOT NULL UNIQUE,
     urldir    varchar(128) NOT NULL,
     enabled  boolean NOT NULL,
     region  varchar(2),


### PR DESCRIPTION
Add unique index on hostnames
so that salt cannot import all servers multiple times.

For this we have to drop some duplicate mirror server entries.